### PR TITLE
feat(groupix-spinner): Add size and color inputs

### DIFF
--- a/projects/groupix-spinner/README.md
+++ b/projects/groupix-spinner/README.md
@@ -46,28 +46,33 @@ export class AppModule {}
 <groupix-spinner></groupix-spinner>
 ```
 
-<!-- 
 ---
+
 ## 🎨 Customization
 
-Modify the styles using CSS:
+You can customize the spinner's appearance using the `size` and `color` input properties.
 
-```css
-groupix-spinner {
-  display: block;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  border: 5px solid rgba(0, 0, 0, 0.1);
-  border-top-color: #3498db;
-  animation: spin 1s linear infinite;
-}
+### `size`
+The `size` input allows you to control the width and height of each ball in the spinner. It accepts any valid CSS size string. If not provided, it defaults to `'40px'`.
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-``` -->
+**Example:**
+```html
+<groupix-spinner [size]="'60px'"></groupix-spinner>
+```
+
+### `color`
+The `color` input allows you to set a uniform background color for all balls in the spinner. It accepts any valid CSS color string (e.g., hex codes, color names). If not provided, the default multi-color gradient backgrounds will be used.
+
+**Example:**
+```html
+<groupix-spinner [color]="'#3498db'"></groupix-spinner>
+```
+
+### Combining Inputs
+You can use both inputs together:
+```html
+<groupix-spinner [size]="'50px'" [color]="'green'"></groupix-spinner>
+```
 
 ---
 

--- a/projects/groupix-spinner/src/lib/groupix-spinner.component.ts
+++ b/projects/groupix-spinner/src/lib/groupix-spinner.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
   selector: 'groupix-spinner',
   template: ` <div class="loader-container">
-    <div class="ball ball-1"></div>
-    <div class="ball ball-2"></div>
-    <div class="ball ball-3"></div>
+    <div class="ball ball-1" [ngStyle]="ball1Style"></div>
+    <div class="ball ball-2" [ngStyle]="ball2Style"></div>
+    <div class="ball ball-3" [ngStyle]="ball3Style"></div>
   </div>`,
   styles: `
   .loader-container {
@@ -17,12 +17,8 @@ import { Component } from '@angular/core';
 }
 
 .ball {
-  width: 40px;
-  height: 40px;
   border-radius: 50%;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   animation: bounce 1.5s infinite ease-in-out;
-  transition: transform 0.3s ease-in-out;
 }
 
 .ball-1 {
@@ -39,10 +35,6 @@ import { Component } from '@angular/core';
   background: linear-gradient(to right, #a855f7, #2563eb);
 }
 
-.ball:hover {
-  transform: scale(1.25);
-}
-
 @keyframes bounce {
   0%, 100% {
     transform: translateY(0);
@@ -53,4 +45,26 @@ import { Component } from '@angular/core';
 }
 `,
 })
-export class GroupixSpinnerComponent {}
+export class GroupixSpinnerComponent implements OnInit {
+  @Input() size: string = '40px';
+  @Input() color!: string;
+
+  ball1Style: any;
+  ball2Style: any;
+  ball3Style: any;
+
+  ngOnInit(): void {
+    const baseStyle = {
+      width: this.size,
+      height: this.size,
+    };
+
+    if (this.color) {
+      (baseStyle as any).background = this.color;
+    }
+
+    this.ball1Style = { ...baseStyle };
+    this.ball2Style = { ...baseStyle };
+    this.ball3Style = { ...baseStyle };
+  }
+}


### PR DESCRIPTION
### **User description**
This commit introduces new features to the Groupix Spinner component:

-   **Size Customization**: You can now specify the size of the spinner's balls using the `[size]` input property. It accepts any valid CSS size string (e.g., '50px', '3em'). The default size is '40px'.

-   **Color Customization**: You can set a uniform color for all spinner balls using the `[color]` input property. It accepts any valid CSS color string (e.g., '#FF0000', 'blue'). If no color is provided, the spinner will use its default multi-color gradient backgrounds.

The component's internal styling has been updated to support these dynamic inputs. Additionally, some fixed style properties (`box-shadow`, `transition` on hover) were removed from the default ball style to provide you with more control over the spinner's appearance.

The `README.md` has been updated to include documentation and usage examples for these new input properties.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `size` and `color` input properties to `GroupixSpinnerComponent`
  - `size` controls ball dimensions, defaults to '40px'
  - `color` sets uniform ball color, overrides gradients

- Updated component template and logic to apply dynamic styles

- Enhanced documentation with usage examples for new inputs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>groupix-spinner.component.ts</strong><dd><code>Add dynamic size and color inputs to spinner component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/groupix-spinner/src/lib/groupix-spinner.component.ts

<li>Introduced <code>size</code> and <code>color</code> @Input properties<br> <li> Applied dynamic styles to spinner balls using <code>[ngStyle]</code><br> <li> Updated component to implement <code>OnInit</code> for style initialization<br> <li> Removed fixed size, box-shadow, and hover transition from CSS


</details>


  </td>
  <td><a href="https://github.com/ArshdeepGrover/groupix-spinner-library/pull/1/files#diff-5d7241515ec9950d618ca1e313c53ec8577eee33e96b45501f984bdcb00bd892">+27/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for spinner customization inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

projects/groupix-spinner/README.md

<li>Documented new <code>size</code> and <code>color</code> input properties<br> <li> Added usage examples for spinner customization<br> <li> Removed outdated CSS customization section


</details>


  </td>
  <td><a href="https://github.com/ArshdeepGrover/groupix-spinner-library/pull/1/files#diff-fe65fd75eb969d633e5231c6e68dcd955c9a758f96aa0d199518ee5c169bb682">+24/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>